### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
         TASKER_APP_ID: ${{ secrets.TASKER_APP_ID }}
         CI: true
     - name: Build container and push to dockerhub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         BA_ROSTER_URL: ${{ secrets.ROSTER_URL }}
         BA_APP_ID: ${{ secrets.APP_ID }}

--- a/.github/workflows/deploy_pr.yaml
+++ b/.github/workflows/deploy_pr.yaml
@@ -22,7 +22,7 @@ jobs:
         TASKER_APP_ID: ${{ secrets.TASKER_APP_ID }}
         CI: true
     - name: Build container and push to dockerhub
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         BA_ROSTER_URL: ${{ secrets.ROSTER_URL_PR }}
         BA_APP_ID: ${{ secrets.APP_ID_PR }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore